### PR TITLE
Use peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "run-sequence": "^1.1.5",
     "webpack-stream": "^3.1.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "draft-js": "^0.8.1",
     "immutable": "^3.7.6",
     "react": "^0.14.7",


### PR DESCRIPTION
Depending directly on these causes problems. I am using React 15.5.4 and Draft 0.10.1. When packages are installed, the whole `draft-js-typeahead` has its own dependencies inside. Normally it would be probably ok, but I've run into this warning: https://facebook.github.io/react/warnings/refs-must-have-owner.html

Only after removing these dependencies manually in `draft-js-typeahead/node_modules` the warning is gone and things are working just fine.